### PR TITLE
Save validated user to the session to avoid LDAP searches on subseque…

### DIFF
--- a/src/AdminlessUserProvider.php
+++ b/src/AdminlessUserProvider.php
@@ -5,6 +5,7 @@ namespace JotaEleSalinas\AdminlessLdap;
 
 use Illuminate\Contracts\Auth\UserProvider;
 use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Support\Facades\Session;
 
 class AdminlessUserProvider implements UserProvider
 {
@@ -17,7 +18,16 @@ class AdminlessUserProvider implements UserProvider
 
     public function retrieveById($identifier)
     {
-        return $this->retrieveByCredentials([LdapUser::keyName() => $identifier]);
+        // If the identifier matches the validated user saved to the current
+        // session, return this user object to avoid an LDAP search
+        if (Session::has('jotaelesalinas.adminlessldap.validateduser')) {
+            $user = Session::get('jotaelesalinas.adminlessldap.validateduser');
+            if ($user instanceof LdapUser && $user->getAuthIdentifier() == $identifier) {
+                return $user;
+            }
+        }
+
+        return $this->retrieveByCredentials([LdapUser::keyName() => $identifier, 'password' => '']);
     }
 
     public function retrieveByToken($identifier, $token)
@@ -58,6 +68,14 @@ class AdminlessUserProvider implements UserProvider
         $password = $credentials['password'];
 
         // check identifier and password against LDAP server
-        return $this->ldap_helper->checkCredentials($identifier, $password);
+        if (!$this->ldap_helper->checkCredentials($identifier, $password)) {
+            return false;
+        }
+
+        // check credentials succeeded, so store the user object in the session to avoid
+        // LDAP searches on subsequent requests
+        Session::put('jotaelesalinas.adminlessldap.validateduser', $user);
+
+        return true;
     }
 }


### PR DESCRIPTION
…nt requests [refs #49]

<!--- Provide a general summary of your changes in the Title above -->

## Description

Stores the LdapUser object of the validated user to the session and retrieve it on subsequent requests to avoid having to LDAP search on non log-in requests. This also addresses the problem of `AdminlessUserProvider::retrieveById` not supplying a password in the credentials array when falling back to a directory lookup through calling `retrieveByCredentials`.

## Motivation and context

* Fix PHP error when attempting to reference unset `$credentials['password']` array key in `retrieveByCredentials` (issus https://github.com/jotaelesalinas/laravel-adminless-ldap-auth/issues/49 )
* Allow `LdapUser` session user object to be persisted for the life time of the session to avoid reloading the user via an ldap search on none-login requests. This is particularly important for Active Directory users where anonymous binds for searches are not likely to be permitted in most setups.

## How has this been tested?

Tested by hand on a Laravel 8.x site with a Laravel Breeze @AuthenticatedSessionController@ controller talking to a live Active Directory server. Verified login, site navigation as authenticated user, logout, and subsequent site navigation as guest user.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply.

Please, please, please, don't send your pull request until all of the boxes are ticked. Once your pull request is created, it will trigger a build on our [continuous integration](http://www.phptherightway.com/#continuous-integration) server to make sure your [tests and code style pass](https://help.github.com/articles/about-required-status-checks/).

- [ x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [ x] My pull request addresses exactly one patch/feature.
- [ x] I have created a branch for this patch/feature.
- [ x] Each individual commit in the pull request is meaningful.
- [ ] I have added tests to cover my changes.
- [ ] If my change requires a change to the documentation, I have updated it accordingly.

If you're unsure about any of these, don't hesitate to ask. We're here to help!
